### PR TITLE
Replace STATIC_URL by  static tag

### DIFF
--- a/dashing/templates/dashing/base.html
+++ b/dashing/templates/dashing/base.html
@@ -1,4 +1,5 @@
 <!DOCTYPE html>
+{% load static from staticfiles %}
 <html lang="en">
 <head>
     <meta charset="utf-8"/>
@@ -8,10 +9,10 @@
 
     <title>{{title}}</title>
 
-    <link rel="stylesheet" href="{{ STATIC_URL }}lib/css/jquery.gridster.css">
-    <link rel="stylesheet" href="{{ STATIC_URL }}lib/css/rickshaw.css">
-    <link rel="stylesheet" href="{{ STATIC_URL }}lib/css/font-awesome.css">
-    <link rel="stylesheet" href="{{ STATIC_URL }}dashing.css">
+    <link rel="stylesheet" href="{% static 'lib/css/jquery.gridster.css' %}">
+    <link rel="stylesheet" href="{% static 'lib/css/rickshaw.css' %}">
+    <link rel="stylesheet" href="{% static 'lib/css/font-awesome.css' %}">
+    <link rel="stylesheet" href="{% static 'dashing.css' %}">
     {% block 'stylesheets' %}
     {% endblock %}
     <link href='http://fonts.googleapis.com/css?family=Open+Sans:300,400,600,700' rel='stylesheet' type='text/css'>
@@ -29,18 +30,18 @@
         {% block 'templates' %}
         {% endblock %}
     </ul>
-    <script type="text/javascript" src="{{ STATIC_URL }}lib/js/jquery-1.11.0.js"></script>
-    <script type="text/javascript" src="{{ STATIC_URL }}lib/js/jquery.gridster.js"></script>
-    <script type="text/javascript" src="{{ STATIC_URL }}lib/js/jquery.knob.js"></script>
-    <script type="text/javascript" src="{{ STATIC_URL }}lib/js/jquery.leanModal.min.js"></script>
-    <script type="text/javascript" src="{{ STATIC_URL }}lib/js/d3.js"></script>
-    <script type="text/javascript" src="{{ STATIC_URL }}lib/js/rickshaw.js"></script>
-    <script type="text/javascript" src="{{ STATIC_URL }}lib/js/moment-with-langs.js"></script>
-    <script type="text/javascript" src="{{ STATIC_URL }}dashing.js"></script>
+    <script type="text/javascript" src="{% static 'lib/js/jquery-1.11.0.js' %}"></script>
+    <script type="text/javascript" src="{% static 'lib/js/jquery.gridster.js' %}"></script>
+    <script type="text/javascript" src="{% static 'lib/js/jquery.knob.js' %}"></script>
+    <script type="text/javascript" src="{% static 'lib/js/jquery.leanModal.min.js' %}"></script>
+    <script type="text/javascript" src="{% static 'lib/js/d3.js' %}"></script>
+    <script type="text/javascript" src="{% static 'lib/js/rickshaw.js' %}"></script>
+    <script type="text/javascript" src="{% static 'lib/js/moment-with-langs.js' %}"></script>
+    <script type="text/javascript" src="{% static 'dashing.js' %}"></script>
     {% block 'scripts' %}
     {% endblock %}
     {% block 'config_file' %}
-    <script type="text/javascript" src="{{ STATIC_URL }}dashing-config.js"></script>
+    <script type="text/javascript" src="{% static 'dashing-config.js' %}"></script>
     {% endblock %}
 </body>
 </html>

--- a/dashing/templates/dashing/dashboard.html
+++ b/dashing/templates/dashing/dashboard.html
@@ -1,17 +1,18 @@
 {% extends 'dashing/base.html' %}
+{% load static from staticfiles %}
 
 {% block 'stylesheets' %}
-<link rel="stylesheet" href="{{ STATIC_URL }}widgets/clock/clock.css">
-<link rel="stylesheet" href="{{ STATIC_URL }}widgets/list/list.css">
-<link rel="stylesheet" href="{{ STATIC_URL }}widgets/number/number.css">
-<link rel="stylesheet" href="{{ STATIC_URL }}widgets/graph/graph.css">
+<link rel="stylesheet" href="{% static 'widgets/clock/clock.css' %}">
+<link rel="stylesheet" href="{% static 'widgets/list/list.css' %}">
+<link rel="stylesheet" href="{% static 'widgets/number/number.css' %}">
+<link rel="stylesheet" href="{% static 'widgets/graph/graph.css' %}">
 {% endblock %}
 
 {% block 'scripts' %}
-<script type="text/javascript" src="{{ STATIC_URL }}widgets/clock/clock.js"></script>
-<script type="text/javascript" src="{{ STATIC_URL }}widgets/list/list.js"></script>
-<script type="text/javascript" src="{{ STATIC_URL }}widgets/number/number.js"></script>
-<script type="text/javascript" src="{{ STATIC_URL }}widgets/graph/graph.js"></script>
+<script type="text/javascript" src="{% static 'widgets/clock/clock.js' %}"></script>
+<script type="text/javascript" src="{% static 'widgets/list/list.js' %}"></script>
+<script type="text/javascript" src="{% static 'widgets/number/number.js' %}"></script>
+<script type="text/javascript" src="{% static 'widgets/graph/graph.js' %}"></script>
 {% endblock %}
 
 {% block 'templates' %}


### PR DESCRIPTION
I've replaced {{ STATIC_URL }} variable by Django 1.5 new {% static %} tag. Without %static tag, django-dashing required some special settings.

I would like ask you to merge this pull request.

Tested on Django 1.6, should work in Django 1.5  according to the [Django documentation](https://docs.djangoproject.com/en/1.5/ref/contrib/staticfiles/#std:templatetag-staticfiles-static)
