### PR TITLE
Allow configuration of required permissions

### DIFF
--- a/dashing/settings.py
+++ b/dashing/settings.py
@@ -1,0 +1,17 @@
+from django.conf import settings
+from django.contrib.auth import REDIRECT_FIELD_NAME
+from django.contrib.auth.decorators import user_passes_test
+
+def user_test(view_func, redirect_field_name=REDIRECT_FIELD_NAME, login_url='admin:login'):
+    return user_passes_test(
+        lambda u: True,
+        login_url=login_url,
+        redirect_field_name=redirect_field_name
+    )(view_func)
+
+
+_g = globals()
+for key, value in _g.items():
+    _g[key] = getattr(settings, key, value)
+
+

--- a/dashing/views.py
+++ b/dashing/views.py
@@ -1,11 +1,12 @@
 # -*- encoding: utf-8 -*-
 from django.views.generic import TemplateView
 from django.utils.decorators import method_decorator
-from django.contrib.admin.views.decorators import staff_member_required
+
+from .settings import user_test
 
 class Dashboard(TemplateView):
     template_name = 'dashing/dashboard.html'
-    
-    @method_decorator(staff_member_required)
+
+    @method_decorator(user_test)
     def dispatch(self, *args, **kwargs):
         return super(Dashboard, self).dispatch(*args, **kwargs)


### PR DESCRIPTION
## Summary

On local intranets or premise devices that do not have keyboards for performing logins, it is not favourable to require staff level permissions and perhaps you wish to authenticate by request IP or something else. 

This allows you to use whatever permissions you want by specifying in your settings file.
