### PR TITLE
Use relative path for fonts

### DIFF
--- a/dashing/static/lib/css/font-awesome.css
+++ b/dashing/static/lib/css/font-awesome.css
@@ -6,8 +6,8 @@
  * -------------------------- */
 @font-face {
   font-family: 'FontAwesome';
-  src: url('/static/fonts/fontawesome-webfont.eot?v=4.0.3');
-  src: url('/static/fonts/fontawesome-webfont.eot?#iefix&v=4.0.3') format('embedded-opentype'), url('/static/fonts/fontawesome-webfont.woff?v=4.0.3') format('woff'), url('/static/fonts/fontawesome-webfont.ttf?v=4.0.3') format('truetype'), url('/static/fonts/fontawesome-webfont.svg?v=4.0.3#fontawesomeregular') format('svg');
+  src: url('../../fonts/fontawesome-webfont.eot?v=4.0.3');
+  src: url('../../fonts/fontawesome-webfont.eot?#iefix&v=4.0.3') format('embedded-opentype'), url('../../fonts/fontawesome-webfont.woff?v=4.0.3') format('woff'), url('../../fonts/fontawesome-webfont.ttf?v=4.0.3') format('truetype'), url('../../fonts/fontawesome-webfont.svg?v=4.0.3#fontawesomeregular') format('svg');
   font-weight: normal;
   font-style: normal;
 }


### PR DESCRIPTION
Hi,

first, congrats for your work, this dashboard is really nice.

I encountered an issue with awesome fonts deploying on a server with a static url like http://static.example.com/foo/. Because of the use of absolute urls in the `font-awesome.css` file, the system tried to load the font file from http://static.example.com/static/fonts/fontawesome-webfont.woff?v=4.0.3 instead of looking to http://static.example.com/foo/fonts/fontawesome-webfont.woff?v=4.0.3.

So I only replace the `/static/fonts/` in the css file by `../../fonts/`.

Guillaume