### PR TITLE
Manage Rickshaw.Graph properties

### DIFF
--- a/dashing/static/widgets/graph/graph.js
+++ b/dashing/static/widgets/graph/graph.js
@@ -21,40 +21,46 @@ rivets.getId = function() {
     return o;
 };
 
-rivets.binders['dashing-graph'] = function(el, data) {
-    var container = el.parentNode, id, graph, xAxis, yAxis;
-    if (!data) return;
-    if (!$(container).is(':visible')) return;
-    if (data.beforeRender) data.beforeRender();
-    if (/rickshaw_graph/.test(container.className)) {
-        graph = window[container.dataset.id];
-        graph.series[0].data = data;
-        graph.update();
-        return;
-    }
-    id = rivets.getId();
-    graph = new Rickshaw.Graph({
-        element: container, 
-        width: container.width, 
-        height: container.height, 
-        series: [{
-            color: '#fff',
-            data: data
-        }]
-    });
-    graph.render();
+rivets.binders['dashing-graph'] = {
+    bind: function(el) {
+        properties = this.model.properties || {};
+    },
+    routine: function(el, data) {
+        var container = el.parentNode, id, graph, xAxis, yAxis;
+        if (!data) return;
+        if (!$(container).is(':visible')) return;
+        if (data.beforeRender) data.beforeRender();
+        if (/rickshaw_graph/.test(container.className)) {
+            graph = window[container.dataset.id];
+            graph.series[0].data = data;
+            graph.update();
+            return;
+        }
+        id = rivets.getId();
+        graph = new Rickshaw.Graph({
+            element: container,
+            width: container.width,
+            height: container.height,
+            series: [{
+                color: '#fff',
+                data: data
+            }]
+        });
+        graph.configure(properties);
+        graph.render();
 
-    xAxis = new Rickshaw.Graph.Axis.X({
-        graph: graph,
-        tickFormat: data.xFormat || Rickshaw.Fixtures.Number.formatKMBT
-    });
-    yAxis = new Rickshaw.Graph.Axis.Y({
-        graph: graph,
-        tickFormat: data.yFormat || Rickshaw.Fixtures.Number.formatKMBT
-    });
-    xAxis.render();
-    yAxis.render();
-    if (data.afterRender) data.afterRender();
-    window[id] = graph;
-    container.dataset.id = id;
+        xAxis = new Rickshaw.Graph.Axis.X({
+            graph: graph,
+            tickFormat: data.xFormat || Rickshaw.Fixtures.Number.formatKMBT
+        });
+        yAxis = new Rickshaw.Graph.Axis.Y({
+            graph: graph,
+            tickFormat: data.yFormat || Rickshaw.Fixtures.Number.formatKMBT
+        });
+        xAxis.render();
+        yAxis.render();
+        if (data.afterRender) data.afterRender();
+        window[id] = graph;
+        container.dataset.id = id;
+    }
 };

--- a/dashing/widgets.py
+++ b/dashing/widgets.py
@@ -96,6 +96,7 @@ class GraphWidget(Widget):
     more_info = ''
     value = ''
     data = []
+    properties = {}
 
     def get_title(self):
         return self.title
@@ -109,10 +110,14 @@ class GraphWidget(Widget):
     def get_data(self):
         return self.data
 
+    def get_properties(self):
+        return self.properties
+
     def get_context(self):
         return {
             'title': self.get_title(),
             'more_info': self.get_more_info(),
             'value': self.get_value(),
             'data': self.get_data(),
+            'properties': self.get_properties(),
         }


### PR DESCRIPTION
Hi,

I updated the graph widget to manage all the [Rickshaw.Graph properties](https://github.com/shutterstock/rickshaw#rickshawgraph). 

I added an optional `properties` key to the json object:

    {
        data: [
            { x: 0, y: 29 },
            { x: 1, y: 42 },
            { x: 2, y: 12 }
        ],
        value: 12,
        title: 'Yeah !',
        more_info: 'Django Rocks',
        properties: {
            renderer: 'line',
            padding: { top: 0.1, right: 0.1 }
        },
    }

The properties are assigned to the graph before the rendering using the `Rickshaw.Graph.configure()` method.

In addition, I plan to add support for the [extensions](https://github.com/shutterstock/rickshaw#extensions).