### PR TITLE
added beforeRender, afterRender, xFormat and yFormat as defaults to scop...

### DIFF
--- a/dashing/static/widgets/graph/graph.js
+++ b/dashing/static/widgets/graph/graph.js
@@ -6,7 +6,12 @@ Dashing.widgets.Graph = function (dashboard) {
     self.__init__ =  Dashing.utils.widgetInit(dashboard, 'graph');
     self.row = 1;
     self.col = 2;
-    self.scope = {};
+    self.scope = {
+        beforeRender: function() {},
+        afterRender: function() {},
+        xFormat: function() {},
+        yFormat: function() {}
+    };
     self.getWidget = function () {
         return widget;
     };


### PR DESCRIPTION
...e of Graph widget

While checking for a solution to #23, I found that the four methods were not available as I 'overwrote' the scope in the widget in django-dashing.js like

```
scope: {
    title: 'FC Sessions',
    value: 'Error value'
},
```

This would now be the case as well, but if someone just uses ```$.extend(self.scope, scope)``` this shouldn't happen anymore. 

fixes #23 