### PR TITLE
add python 3.4 to supported languages in setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -25,6 +25,7 @@ setup(
         'Operating System :: OS Independent',
         'Programming Language :: Python',
         'Programming Language :: Python :: 2.7',
+        'Programming Language :: Python :: 3.4',
         'Topic :: Internet :: WWW/HTTP',
         'Topic :: Internet :: WWW/HTTP :: Dynamic Content',
         'Topic :: Software Development :: Libraries :: Python Modules',


### PR DESCRIPTION
Basic usage works with python 3.4 and pylint doesn't discover anything too catastrophic. Is there a reason python 3 support is not mentioned?
