### PR TITLE
Add padding for Knob Widget to avoid text overlap

### DIFF
--- a/dashing/static/dashing/widgets/knob/knob.css
+++ b/dashing/static/dashing/widgets/knob/knob.css
@@ -14,6 +14,7 @@
     font-weight: 500;
     font-size: 30px;
     color: #fff;
+    padding-bottom: 20px;
 }
 
 .widget-knob .more-info {


### PR DESCRIPTION
Using the default `dashing-config.js`, for the `knob` widget the `.detail` text overlaps with the `.update-at` text.

Here is a screenshot:
![before-knob-overlap](https://cloud.githubusercontent.com/assets/241185/14367883/45ae850a-fccf-11e5-93df-94b8242a2a1c.png)
Notice the overlap at the bottom of the page. "today 10" overlaps with "Last updated at 14:10".

This patch introduces some padding for the `.detail` element in order to avoid the overlap. Here is the same page after the patch is applied:
![after-knob-no-overlap](https://cloud.githubusercontent.com/assets/241185/14367887/4a08967c-fccf-11e5-9eca-efdcfacc6204.png)

