### PR TITLE
Add value to Knob Widget

### DIFF
--- a/dashing/widgets.py
+++ b/dashing/widgets.py
@@ -141,6 +141,7 @@ class GraphWidget(Widget):
 
 class KnobWidget(Widget):
     title = ''
+    value = ''
     data = {}
     detail = ''
     more_info = ''
@@ -158,12 +159,16 @@ class KnobWidget(Widget):
     def get_more_info(self):
         return self.more_info
 
+    def get_value(self):
+        return self.value
+
     def get_updated_at(self):
         return self.updated_at
 
     def get_context(self):
         return {
             'title': self.get_title(),
+            'value': self.get_value(),
             'data': self.get_data(),
             'detail': self.get_detail(),
             'moreInfo': self.get_more_info(),


### PR DESCRIPTION
The Knob Widget requires a `value` in `scope`. One could override `get_context` and provide a `value`, but, similar to other widgets, it is better to have a `value` field and `get_value` member. This way `get_context` can use them and the user just has to override `get_value`. This patch adds the `value` field and `get_value` member.