### PR TITLE
Example of using the percent sign in Knob Widget

### DIFF
--- a/dashing/static/dashing-config.js
+++ b/dashing/static/dashing-config.js
@@ -67,7 +67,8 @@ dashboard.addWidget('completion_widget', 'Knob', {
                 step: 1,
                 min: 1,
                 max: 99,
-                readOnly: true
+                readOnly: true,
+                format: function(value) { return value + '%'; }
             }
         });
     }


### PR DESCRIPTION
This is an example of how to use the percent sign in the Knob Widget. This patch adds this example to the default `dashing-config.js` file.
