### PR TITLE
map: add support for specifying a Google Maps API key

### DIFF
--- a/dashing/settings.py
+++ b/dashing/settings.py
@@ -11,7 +11,8 @@ DEFAULTS = {
     'PERMISSION_CLASSES':  (
         'dashing.permissions.AllowAny',
     ),
-    'LOCALES': ()
+    'LOCALES': (),
+    'WIDGET_CONFIGS': {},
 }
 
 # List of settings that may be in string import notation.

--- a/dashing/static/dashing/dashing.js
+++ b/dashing/static/dashing/dashing.js
@@ -23,7 +23,8 @@
                             googleMapsScript = document.createElement('script');
                         googleMapsScript.type = 'text/javascript';
                         googleMapsScript.src = 'https://maps.googleapis.com/maps/api/js' +
-                                               '?v=3.exp&callback=__googlemapscallbackfunc__';
+                                               '?v=3.exp&callback=__googlemapscallbackfunc__' +
+                                               '&key=' + GOOGLE_MAPS_API_KEY;
                         window.__googlemapscallbackfunc__ = function() {
                             self.publish('complete');
                         };

--- a/dashing/templates/dashing/base.html
+++ b/dashing/templates/dashing/base.html
@@ -53,6 +53,7 @@
     {% endblock %}
     {% compress js %}
     <script type="text/javascript">var DASHING_STATIC = "{% static 'dashing/' %}";</script>
+    {% widget_configs %}
     <script type="text/javascript" src="{% static 'dashing/libs/jquery-1.11.0.js' %}"></script>
     <script type="text/javascript" src="{% static 'dashing/libs/sightglass.js' %}"></script>
     <script type="text/javascript" src="{% static 'dashing/libs/rivets.js' %}"></script>

--- a/dashing/templatetags/dashing_tags.py
+++ b/dashing/templatetags/dashing_tags.py
@@ -76,6 +76,18 @@ def widget_templates():
     return load('<link rel="resource" type="text/html" '
                 'href="{}" data-widget="{}">\n', 'html')
 
+
+@register.simple_tag
+def widget_configs():
+    widgets = dashing_settings.INSTALLED_WIDGETS
+    output = ''
+    for name in widgets:
+        if name in dashing_settings.WIDGET_CONFIGS:
+            for key, value in dashing_settings.WIDGET_CONFIGS[name].items():
+                output += '<script type="text/javascript">var {} = "{}";</script>'.format(key, value)
+    return mark_safe(output)
+
+
 if "compressor" in settings.INSTALLED_APPS:
     @register.tag
     def compress(parser, token):

--- a/docs/getting-started.rst
+++ b/docs/getting-started.rst
@@ -113,6 +113,18 @@ Default:
 
     () # empty tuple, english default
 
+
+**WIDGET_CONFIGS**
+
+A widget name -> {key: value} dictionary holding any additional configuration values needed for some of your ``INSTALLED_WIDGETs``, such as API keys.
+
+Default:
+
+.. code-block:: python
+
+    {} # empty dict, no additional configuration
+
+
 Config File 
 -----------
 

--- a/docs/getting-started.rst
+++ b/docs/getting-started.rst
@@ -116,7 +116,7 @@ Default:
 
 **WIDGET_CONFIGS**
 
-A widget name -> {key: value} dictionary holding any additional configuration values needed for some of your ``INSTALLED_WIDGETs``, such as API keys.
+A widget name -> {key: value} dictionary holding any additional configuration values needed for some of your ``INSTALLED_WIDGETS``, such as API keys.
 
 Default:
 

--- a/docs/widgets.rst
+++ b/docs/widgets.rst
@@ -415,6 +415,21 @@ Map Widget
 
 This widget display a google map widget with one or more markers grouped
 
+You need to specify your GoogleMaps API key in ``WIDGET_CONFIGS`` for this widget to work properly, using the ``GOOGLE_MAPS_API_KEY`` key. For example:
+
+
+.. code-block:: python
+
+    DASHING = {
+        'INSTALLED_WIDGETS': ('number', 'list', 'map',),
+        'WIDGET_CONFIGS': {
+                'map': {
+                        'GOOGLE_MAPS_API_KEY': '<insert your GoogleMaps API key here>',
+                },
+        },
+    }
+
+
 Options
 ~~~~~~~~~~~~
 


### PR DESCRIPTION
I did not get the map widget to work without adding a Google Maps API key to the JS script loading function, hence this PR.

It's implemented using an additional settings key, ``WIDGET_CONFIGS``, to hold the API key, because as I understand it it's not possible to have it in ``dashing-config.js`` since the Google Maps javascript has already been loaded earlier in ``dashing.js``. I added a new template tag, ``widget_configs``, similar to the existing styles and scripts tags, since once again I saw no over simpler way to do it.

If you agree with the way this is implemented I'll go about updating the docs as well to explain how the new settings key must be used (it's basically a widget name -> {key, value} dict that ends pushed down as ``<script>`` snippets in ``base.html``).