### PR TITLE
Use Https for loading Open Sans

### DIFF
--- a/dashing/templates/dashing/base.html
+++ b/dashing/templates/dashing/base.html
@@ -22,7 +22,7 @@
     {% block templates %}
     {% endblock %}
     {% block external_resources %}
-    <link href='http://fonts.googleapis.com/css?family=Open+Sans:300,400,600,700' rel='stylesheet' type='text/css'>
+    <link href='https://fonts.googleapis.com/css?family=Open+Sans:300,400,600,700' rel='stylesheet' type='text/css'>
     {% endblock %}
     <link rel="icon" href="/assets/images/favicon.ico">
 </head>


### PR DESCRIPTION
This PR changes to using https for loading the font from google fonts.

I was getting a mixed content warning when loading this font:

```
Mixed Content: The page at
'https://example.com/dash/dashboard/' was loaded over
HTTPS, but requested an insecure stylesheet
'http://fonts.googleapis.com/css?family=Open+Sans:300,400,600,700'. This
request has been blocked; the content must be served over HTTPS.
```

Thoughts?