### PR TITLE
Fix/issue 73

### DIFF
--- a/dashing/static/dashing/dashing.js
+++ b/dashing/static/dashing/dashing.js
@@ -5,9 +5,15 @@
         scope = {grids: [], toggleOverlay: function() {}};
     Dashing = {
         resources: {
-            d3: DASHING_STATIC + 'libs/d3/d3.min.js',
-            rickshaw: DASHING_STATIC + 'libs/rickshaw/rickshaw.min.js',
-            jqueryKnob: DASHING_STATIC + 'libs/jquery-knob/jquery.knob.min.js',
+            d3: {
+              src: DASHING_STATIC + 'libs/d3/d3.min.js',
+            },
+            rickshaw: {
+              src: DASHING_STATIC + 'libs/rickshaw/rickshaw.min.js',
+            },
+            jqueryKnob: {
+              src: DASHING_STATIC + 'libs/jquery-knob/jquery.knob.min.js',
+            },
             googleMaps: {
                 Loader: function() {
                     this.on = function(id, func) {
@@ -265,3 +271,4 @@
     global.DashboardSet = DashboardSet;
     global.scope = scope;
 })(window, window.console || {warn: alert.bind(null), error: alert.bind(null)});
+

--- a/dashing/static/dashing/dashing.utils.js
+++ b/dashing/static/dashing/dashing.utils.js
@@ -30,17 +30,23 @@
                 if (!options.require) return;
 
                 (function loadResource(name) {
-                    var resource = Dashing.resources[name], loader;
-                    if (!resource) return;
-                    delete Dashing.resources[name];
+                    if (!name) return;
+                    var resource = Dashing.resources[name];
+                    if (resource.loaded && options.require.length) {
+                        loadResource(options.require.shift());
+                        return;
+                    } else if (resource.loaded) {
+                        return;
+                    }
 
-                    loader = resource.Loader ? new resource.Loader() :
-                             new createjs.JavaScriptLoader({src: resource});
-                    loader.on('complete', function() {
+                    resource.loader = resource.Loader ? new resource.Loader() :
+                             new createjs.JavaScriptLoader({src: resource.src});
+                    resource.loader.on('complete', function() {
+                        resource.loaded = true;
                         $(document).trigger('libs/' + name + '/loaded');
                         loadResource(options.require.shift());
                     });
-                    loader.load();
+                    resource.loader.load();
                 })(options.require.shift());
 
             };
@@ -88,3 +94,4 @@
         Version: global.__dashingversion__.constructor
     };
 })(window, window.Dashing);
+

--- a/package.json
+++ b/package.json
@@ -20,7 +20,8 @@
   },
   "homepage": "https://github.com/talpor/django-dashing",
   "dependencies": {
-    "mocha": "^2.1.0",
-    "phantom": "^0.7.2"
+    "mocha": "^3.2.0",
+    "phantom": "^3.2.1",
+    "promise-retry": "^1.1.1"
   }
 }

--- a/test/integration.js
+++ b/test/integration.js
@@ -60,94 +60,88 @@ describe('django-dashing tests:', function() {
         }());
     });
     describe('displaying starter dashboard', function() {
-        it('should display dashboard page with the right title', function(done) {
-            browser.open('/dashboard/').then(function (status) {
+        it('should display dashboard page with the right title', function() {
+            return browser.open('/dashboard/').then(function (status) {
                 var page = browser.page;
                 assert.equal('success', status);
-                page.evaluate( function () {
+                return page.evaluate( function () {
                     return document.title;
-                })
-                .then( function (title) {
-                    assert.equal(title, 'Django Dashing');
-                    done();
                 });
+            })
+            .then( function (title) {
+                assert.equal(title, 'Django Dashing');
             });
         });
-        it('should have a variable called ´dashboard´', function(done) {
-            browser.open('/dashboard/').then( function (status) {
+        it('should have a variable called ´dashboard´', function() {
+            return browser.open('/dashboard/').then( function (status) {
                 var page = browser.page;
                 assert.equal('success', status);
-                page.evaluate( function () {
+                return page.evaluate( function () {
                     /* jshint ignore:start */
                     return (dashboard instanceof Dashboard);
                     /* jshint ignore:end */
-                })
-                .then( function (instanceofDashboard) {
-                    assert.ok(instanceofDashboard);
-                    done();
                 });
+            })
+            .then( function (instanceofDashboard) {
+                assert.ok(instanceofDashboard);
             });
         });
-        it('should have an active dashboard', function(done) {
-            browser.open('/dashboard/').then( function (status) {
+        it('should have an active dashboard', function() {
+            return browser.open('/dashboard/').then( function (status) {
                 var page = browser.page;
                 assert.equal('success', status);
-                page.evaluate( function () {
+                return page.evaluate( function () {
                     /* jshint ignore:start */
                     return dashboard.grid.active;
                     /* jshint ignore:end */
-                })
-                .then( function (isActive) {
-                    assert.ok(isActive);
-                    done();
                 });
+            })
+            .then( function (isActive) {
+                assert.ok(isActive);
             });
         });
-        it('should display five widgets', function(done) {
-            browser.open('/dashboard/').then( function (status) {
+        it('should display five widgets', function() {
+            return browser.open('/dashboard/').then( function (status) {
                 var page = browser.page;
                 assert.equal('success', status);
-                page.evaluate( function () {
+                return page.evaluate( function () {
                     /* jshint ignore:start */
                     return dashboard.getWidgets().length;
                     /* jshint ignore:end */
-                })
-                .then( function (length) {
-                    assert.equal(length, 5);
-                    done();
                 });
+            })
+            .then( function (length) {
+                assert.equal(length, 5);
             });
         });
     });
     describe('displaying multiple dashboards', function() {
-        it('should display dashboard page with the right title', function(done) {
-            browser.open('/multiple_dashboards/').then( function (status) {
+        it('should display dashboard page with the right title', function() {
+            return browser.open('/multiple_dashboards/').then( function (status) {
                 var page = browser.page;
                 assert.equal('success', status);
-                page.evaluate( function () {
+                return page.evaluate( function () {
                     return document.title;
-                })
-                .then( function (title) {
-                    assert.equal(title, 'Multiple Dashboards');
-                    done();
                 });
+            })
+            .then( function (title) {
+                assert.equal(title, 'Multiple Dashboards');
             });
         });
         it('should show the menu overlay when toggleOverlay is fired' +
-           'with the ctrl key down event', function(done) {
-            browser.open('/multiple_dashboards/').then( function (status) {
+           'with the ctrl key down event', function() {
+            return browser.open('/multiple_dashboards/').then( function (status) {
                 var page = browser.page;
                 assert.equal('success', status);
-                page.evaluate( function () {
+                return page.evaluate( function () {
                     /* jshint ignore:start */
                     scope.toggleOverlay({which: 17});
                     return $('#overlayContainer>div').hasClass('in');
                     /* jshint ignore:end */
-                })
-                .then( function (overlayShown) {
-                    assert.ok(overlayShown);
-                    done();
                 });
+            })
+            .then( function (overlayShown) {
+                assert.ok(overlayShown);
             });
         });
     });

--- a/test/integration.js
+++ b/test/integration.js
@@ -144,6 +144,20 @@ describe('django-dashing tests:', function() {
                 assert.ok(overlayShown);
             });
         });
+        it('should have both rickshaw and d3 available', function() {
+            return browser.open('/multiple_dashboards/').then( function (status) {
+                var page = browser.page;
+                assert.equal('success', status);
+                return page.evaluate( function () {
+                    /* jshint ignore:start */
+                    return d3 !== undefined && Rickshaw !== undefined;
+                    /* jshint ignore:end */
+                });
+            })
+            .then( function (isAvailable) {
+                assert.ok(isAvailable);
+            });
+        });
     });
     after(function() {
         browser.instance.exit();

--- a/test/integration.js
+++ b/test/integration.js
@@ -4,6 +4,7 @@
 var phantom = require('phantom'),
     cp = require('child_process'),
     assert = require('assert'),
+    promiseRetry = require('promise-retry'),
     browser = {},
     server;
 
@@ -23,128 +24,135 @@ describe('django-dashing tests:', function() {
                                             {detached: true});
         });
         // create a browser instance
-        phantom.create(function (ph) {
-            ph.createPage(function (page) {
-                browser.open = function(pathname, callback) {
-                    page.open.apply(page,
-                            ['http://127.0.0.1:' + PORT + pathname,
-                             callback.bind(page)]);
-                };
-                browser.exit = ph.exit.bind(null);
-            });
+        phantom.create()
+          .then(function (instance) {
+            browser.instance = instance;
+            return instance.createPage();
+        })
+        .then(function (page) {
+            browser.page = page;
+            browser.open = function(pathname) {
+                var url = 'http://127.0.0.1:' + PORT + pathname;
+                return page.open(url);
+            };
         });
     });
+
     it('should run a django server', function(done) {
+        this.timeout(10000);
         (function waitingForResources() {
             if (server === undefined || browser.open === undefined) {
                 setTimeout(waitingForResources, 100);
             }
             else {
                 // Waiting for the overall server load
-                setTimeout(done, 1000);
+                promiseRetry( function(retry) {
+                    return browser.open('/')
+                    .then(function(status) {
+                        if (status != 'success') {
+                            retry();
+                        } else {
+                            done();
+                        }
+                    });
+                }, {minTimeout: 100, maxTimeout: 1000, retries: 10});
             }
         }());
     });
     describe('displaying starter dashboard', function() {
         it('should display dashboard page with the right title', function(done) {
-            browser.open('/dashboard/', function (status) {
-                var page = this;
+            browser.open('/dashboard/').then(function (status) {
+                var page = browser.page;
                 assert.equal('success', status);
-                page.evaluate(
-                    function () {
-                        return document.title;
-                    },
-                    function (title) {
-                        assert.equal(title, 'Django Dashing');
-                        done();
-                    });
+                page.evaluate( function () {
+                    return document.title;
+                })
+                .then( function (title) {
+                    assert.equal(title, 'Django Dashing');
+                    done();
+                });
             });
         });
         it('should have a variable called ´dashboard´', function(done) {
-            browser.open('/dashboard/', function (status) {
-                var page = this;
+            browser.open('/dashboard/').then( function (status) {
+                var page = browser.page;
                 assert.equal('success', status);
-                page.evaluate(
-                    function () {
-                        /* jshint ignore:start */
-                        return (dashboard instanceof Dashboard);
-                        /* jshint ignore:end */
-                    },
-                    function (instanceofDashboard) {
-                        assert.ok(instanceofDashboard);
-                        done();
-                    });
+                page.evaluate( function () {
+                    /* jshint ignore:start */
+                    return (dashboard instanceof Dashboard);
+                    /* jshint ignore:end */
+                })
+                .then( function (instanceofDashboard) {
+                    assert.ok(instanceofDashboard);
+                    done();
+                });
             });
         });
         it('should have an active dashboard', function(done) {
-            browser.open('/dashboard/', function (status) {
-                var page = this;
+            browser.open('/dashboard/').then( function (status) {
+                var page = browser.page;
                 assert.equal('success', status);
-                page.evaluate(
-                    function () {
-                        /* jshint ignore:start */
-                        return dashboard.grid.active;
-                        /* jshint ignore:end */
-                    },
-                    function (isActive) {
-                        assert.ok(isActive);
-                        done();
-                    });
+                page.evaluate( function () {
+                    /* jshint ignore:start */
+                    return dashboard.grid.active;
+                    /* jshint ignore:end */
+                })
+                .then( function (isActive) {
+                    assert.ok(isActive);
+                    done();
+                });
             });
         });
-        it('should display four widgets', function(done) {
-            browser.open('/dashboard/', function (status) {
-                var page = this;
+        it('should display five widgets', function(done) {
+            browser.open('/dashboard/').then( function (status) {
+                var page = browser.page;
                 assert.equal('success', status);
-                page.evaluate(
-                    function () {
-                        /* jshint ignore:start */
-                        return dashboard.listWidgets().length;
-                        /* jshint ignore:end */
-                    },
-                    function (length) {
-                        assert.equal(length, 4);
-                        done();
-                    });
+                page.evaluate( function () {
+                    /* jshint ignore:start */
+                    return dashboard.getWidgets().length;
+                    /* jshint ignore:end */
+                })
+                .then( function (length) {
+                    assert.equal(length, 5);
+                    done();
+                });
             });
         });
     });
     describe('displaying multiple dashboards', function() {
         it('should display dashboard page with the right title', function(done) {
-            browser.open('/multiple_dashboards/', function (status) {
-                var page = this;
+            browser.open('/multiple_dashboards/').then( function (status) {
+                var page = browser.page;
                 assert.equal('success', status);
-                page.evaluate(
-                    function () {
-                        return document.title;
-                    },
-                    function (title) {
-                        assert.equal(title, 'Multiple Dashboards');
-                        done();
-                    });
+                page.evaluate( function () {
+                    return document.title;
+                })
+                .then( function (title) {
+                    assert.equal(title, 'Multiple Dashboards');
+                    done();
+                });
             });
         });
         it('should show the menu overlay when toggleOverlay is fired' +
            'with the ctrl key down event', function(done) {
-            browser.open('/multiple_dashboards/', function (status) {
-                var page = this;
+            browser.open('/multiple_dashboards/').then( function (status) {
+                var page = browser.page;
                 assert.equal('success', status);
-                page.evaluate(
-                    function () {
-                        /* jshint ignore:start */
-                        scope.toggleOverlay({which: 17});
-                        return $('#overlayContainer>div').hasClass('in');
-                        /* jshint ignore:end */
-                    },
-                    function (overlayShown) {
-                        assert.ok(overlayShown);
-                        done();
-                    });
+                page.evaluate( function () {
+                    /* jshint ignore:start */
+                    scope.toggleOverlay({which: 17});
+                    return $('#overlayContainer>div').hasClass('in');
+                    /* jshint ignore:end */
+                })
+                .then( function (overlayShown) {
+                    assert.ok(overlayShown);
+                    done();
+                });
             });
         });
     });
     after(function() {
-        browser.exit();
+        browser.instance.exit();
         process.kill(-server.pid);
     });
 });

--- a/test/test_app/templates/multiple_dashboards.html
+++ b/test/test_app/templates/multiple_dashboards.html
@@ -1,7 +1,7 @@
 {% extends 'dashing/dashboard.html' %}
 {% block external_resources %}{% endblock %}
-{% block 'title' %}Multiple Dashboards{% endblock %}
-{% block 'config_file' %}
+{% block title %}Multiple Dashboards{% endblock %}
+{% block config_file %}
 <script type="text/javascript">
 /* global $, DashboardSet, alert */
 var console = window.console || {log: alert.bind(null)},

--- a/test/test_app/templates/multiple_dashboards.html
+++ b/test/test_app/templates/multiple_dashboards.html
@@ -53,6 +53,45 @@ sub.addWidget('buzzwords_widget', 'List', {
     }
 });
 
+/* define a new widget that only uses d3,
+ * used as part of a test for issue #73
+ * https://github.com/talpor/django-dashing/issues/73
+ *
+ * This must be added to a dashboard before any widget that
+ * requires Rickshaw, or the Rickshaw dependency will cause
+ * d3 to be pulled in.
+ */
+sub.widgets.Issue73 = function (dashboard) {
+    var self = this;
+
+    /* reuse 'number' template */
+    self.__init__ =  Dashing.utils.widgetInit(dashboard, 'number', {
+        require: ['d3'] /* require just d3, not also rickshaw */
+    });
+    self.row = 1;
+    self.col = 1;
+    self.scope = {};
+    self.getWidget = function () {
+        return this.__widget__;
+    };
+    self.getData = function () {};
+    self.interval = 3000;
+};
+
+sub.addWidget('issue-73-widget', 'Issue73', {
+    getData: function () {
+        $.extend(this.scope, {
+            title: 'Current Valuation',
+            moreInfo: 'In billions',
+            updatedAt: 'Last updated at 14:10',
+            detail: '64%',
+            value: '$35'
+        });
+    }
+});
+
+
+
 main.addWidget('convergence_widget1', 'Graph', {
     getData: function () {
         $.extend(this.scope, {


### PR DESCRIPTION
Fixes #73.

Changes dashing dependency loading to continue to attempt to load dependencies
past the first dependency if the first dependency was already loaded by some
other widget.

This is done by changing the resources to be objects with a `src` key, to which
we add a `loaded` key (set to `true`) once it's loaded. If the resource
requested is already loaded and there are more options, `loadResource` continues
with the next resource.

This commit also adds a test for the issue, but creating a new widget type in
the `multiple_dashboards.html` javascript. It loads only `d3`, while the Graph
widget loads both `d3` and `rickshaw`. The integration test now checks that both
`d3` and `Rickshaw` are defined.

Also reworks the test suite to work with phantom 2.