### PR TITLE
fixes is_authenticated not a callable after django 2

### DIFF
--- a/dashing/permissions.py
+++ b/dashing/permissions.py
@@ -27,7 +27,10 @@ class IsAuthenticated(BasePermission):
     """
 
     def has_permission(self, request):
-        return request.user and request.user.is_authenticated()
+        try:
+            return request.user and request.user.is_authenticated()
+        except TypeError:
+            return request.user and request.user.is_authenticated
 
 
 class IsAdminUser(BasePermission):


### PR DESCRIPTION
In django 2 the `user.is_authenticated()` method was deprecated and turned into a `bool`. 