### PR TITLE
docs: Fix simple typo, begining -> beginning

### DIFF
--- a/dashing/static/dashing/libs/moment-with-locales.js
+++ b/dashing/static/dashing/libs/moment-with-locales.js
@@ -1120,10 +1120,10 @@
                     ++week;
                 }
             } else if (w.e != null) {
-                // local weekday -- counting starts from begining of week
+                // local weekday -- counting starts from beginning of week
                 weekday = w.e + dow;
             } else {
-                // default to begining of week
+                // default to beginning of week
                 weekday = dow;
             }
         }

--- a/dashing/static/dashing/libs/moment/moment.js
+++ b/dashing/static/dashing/libs/moment/moment.js
@@ -1136,10 +1136,10 @@
                     ++week;
                 }
             } else if (w.e != null) {
-                // local weekday -- counting starts from begining of week
+                // local weekday -- counting starts from beginning of week
                 weekday = w.e + dow;
             } else {
-                // default to begining of week
+                // default to beginning of week
                 weekday = dow;
             }
         }


### PR DESCRIPTION
There is a small typo in dashing/static/dashing/libs/moment-with-locales.js, dashing/static/dashing/libs/moment/moment.js.

Should read `beginning` rather than `begining`.

