### PR TITLE
docs: Fix a few typos

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -79,7 +79,7 @@ To make your own dashboard and retrieves the data from django you should:
         url(r'^dashboard/', include(router.urls)),
     ]
 
-Create a dashing-config.js file with a widget that retrive the data in your static directory like:
+Create a dashing-config.js file with a widget that retrieve the data in your static directory like:
 
 .. code-block:: javascript
 

--- a/docs/getting-started.rst
+++ b/docs/getting-started.rst
@@ -94,7 +94,7 @@ A remote location with a repositories.json file is specified by the third-party 
 
 **LOCALES**
 
-A list or tuple of locales to load the neccesary i18n resources to configurate momentjs. You can load more than one but by default, one moment will be configured with the first.
+A list or tuple of locales to load the necessary i18n resources to configurate momentjs. You can load more than one but by default, one moment will be configured with the first.
 
 The list of valid locales are:
 


### PR DESCRIPTION
There are small typos in:
- README.rst
- docs/getting-started.rst

Fixes:
- Should read `retrieve` rather than `retrive`.
- Should read `necessary` rather than `neccesary`.



Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md